### PR TITLE
Enable dashboard collection management

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model Collection {
   id          String   @id @default(cuid())
   name        String
   description String?
+  order       Int      @default(0)
   isPublic    Boolean  @default(false)
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
@@ -41,6 +42,7 @@ model Collection {
 
   @@index([createdById])
   @@index([createdAt])
+  @@index([order])
 }
 
 model Link {

--- a/src/app/_components/dashboard-collections-manager.tsx
+++ b/src/app/_components/dashboard-collections-manager.tsx
@@ -1,0 +1,411 @@
+"use client";
+
+import {
+  type FormEvent,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
+import { useRouter } from "next/navigation";
+import {
+  Button,
+  Callout,
+  Card,
+  Dialog,
+  Flex,
+  Heading,
+  Text,
+  TextArea,
+  TextField,
+} from "@radix-ui/themes";
+import {
+  DndContext,
+  PointerSensor,
+  type DragEndEvent,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import { CheckIcon, ExclamationTriangleIcon } from "@radix-ui/react-icons";
+
+import { api } from "@/trpc/react";
+
+import { SortableCollectionItem } from "./sortable-collection-item";
+
+export type DashboardCollectionModel = {
+  id: string;
+  name: string;
+  description: string | null;
+  order: number;
+  linkCount: number;
+};
+
+type Feedback = { type: "success" | "error"; message: string } | null;
+
+type DashboardCollectionsManagerProps = {
+  initialCollections: DashboardCollectionModel[];
+};
+
+export function DashboardCollectionsManager({
+  initialCollections,
+}: DashboardCollectionsManagerProps) {
+  const [collections, setCollections] = useState(initialCollections);
+  const [activeCollectionId, setActiveCollectionId] = useState<string | null>(
+    null,
+  );
+  const [isEditing, setIsEditing] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+  const utils = api.useUtils();
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+
+  useEffect(() => {
+    setCollections(initialCollections);
+  }, [initialCollections]);
+
+  useEffect(() => {
+    if (!feedback) return;
+    const timeout = setTimeout(() => setFeedback(null), 3000);
+    return () => clearTimeout(timeout);
+  }, [feedback]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 10 },
+    }),
+  );
+
+  const reorderMutation = api.collection.reorder.useMutation({
+    onSettled: async () => {
+      await utils.collection.getAll.invalidate();
+      router.refresh();
+    },
+  });
+
+  const updateMutation = api.collection.update.useMutation({
+    onSettled: async () => {
+      await utils.collection.getAll.invalidate();
+      router.refresh();
+    },
+  });
+
+  const deleteMutation = api.collection.delete.useMutation({
+    onSettled: async () => {
+      await utils.collection.getAll.invalidate();
+      router.refresh();
+    },
+  });
+
+  const activeCollection = useMemo(
+    () =>
+      collections.find((collection) => collection.id === activeCollectionId) ??
+      null,
+    [collections, activeCollectionId],
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) {
+      return;
+    }
+
+    setCollections((prev) => {
+      const oldIndex = prev.findIndex(
+        (collection) => collection.id === active.id,
+      );
+      const newIndex = prev.findIndex(
+        (collection) => collection.id === over.id,
+      );
+      if (oldIndex === -1 || newIndex === -1) {
+        return prev;
+      }
+
+      const reordered = arrayMove(prev, oldIndex, newIndex);
+      const previous = prev;
+
+      startTransition(() => {
+        reorderMutation.mutate(
+          { collectionIds: reordered.map((collection) => collection.id) },
+          {
+            onSuccess: () =>
+              setFeedback({
+                type: "success",
+                message: "Collection order updated",
+              }),
+            onError: () => {
+              setCollections(previous);
+              setFeedback({
+                type: "error",
+                message: "Unable to update collection order",
+              });
+            },
+          },
+        );
+      });
+
+      return reordered;
+    });
+  };
+
+  const handleEditSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!activeCollection) return;
+
+    const formData = new FormData(event.currentTarget);
+    const nameValue = formData.get("name");
+    const descriptionValue = formData.get("description");
+
+    if (typeof nameValue !== "string" || typeof descriptionValue !== "string") {
+      return;
+    }
+
+    const name = nameValue.trim();
+    const description = descriptionValue.trim();
+
+    if (!name) {
+      return;
+    }
+
+    const previousCollections = collections;
+    setCollections((prev) =>
+      prev.map((collection) =>
+        collection.id === activeCollection.id
+          ? {
+              ...collection,
+              name,
+              description: description.length > 0 ? description : null,
+            }
+          : collection,
+      ),
+    );
+
+    updateMutation.mutate(
+      {
+        id: activeCollection.id,
+        name,
+        description: description.length > 0 ? description : null,
+      },
+      {
+        onSuccess: () => {
+          setFeedback({ type: "success", message: "Collection updated" });
+          setIsEditing(false);
+          setActiveCollectionId(null);
+        },
+        onError: () => {
+          setCollections(previousCollections);
+          setFeedback({
+            type: "error",
+            message: "Unable to update collection",
+          });
+        },
+      },
+    );
+  };
+
+  const handleDelete = () => {
+    if (!activeCollection) return;
+
+    const previousCollections = collections;
+    setCollections((prev) =>
+      prev.filter((collection) => collection.id !== activeCollection.id),
+    );
+
+    deleteMutation.mutate(
+      { id: activeCollection.id },
+      {
+        onSuccess: () => {
+          setFeedback({ type: "success", message: "Collection deleted" });
+          setIsDeleting(false);
+          setActiveCollectionId(null);
+          router.refresh();
+        },
+        onError: () => {
+          setCollections(previousCollections);
+          setFeedback({
+            type: "error",
+            message: "Unable to delete collection",
+          });
+        },
+      },
+    );
+  };
+
+  const isUpdating = updateMutation.isPending;
+  const isDeletingCollection = deleteMutation.isPending;
+
+  return (
+    <Flex direction="column" gap="4">
+      {feedback ? (
+        <Callout.Root
+          color={feedback.type === "success" ? "green" : "red"}
+          role="status"
+        >
+          <Callout.Icon>
+            {feedback.type === "success" ? (
+              <CheckIcon />
+            ) : (
+              <ExclamationTriangleIcon />
+            )}
+          </Callout.Icon>
+          <Callout.Text>{feedback.message}</Callout.Text>
+        </Callout.Root>
+      ) : null}
+
+      {collections.length > 0 ? (
+        <DndContext
+          sensors={sensors}
+          onDragEnd={handleDragEnd}
+          modifiers={[restrictToVerticalAxis]}
+        >
+          <SortableContext
+            items={collections.map((collection) => collection.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <Flex direction="column" gap="3">
+              {collections.map((collection) => (
+                <SortableCollectionItem
+                  key={collection.id}
+                  collection={collection}
+                  onEdit={() => {
+                    setActiveCollectionId(collection.id);
+                    setIsEditing(true);
+                  }}
+                  onDelete={() => {
+                    setActiveCollectionId(collection.id);
+                    setIsDeleting(true);
+                  }}
+                  dragDisabled={reorderMutation.isPending}
+                />
+              ))}
+            </Flex>
+          </SortableContext>
+        </DndContext>
+      ) : (
+        <Card
+          size="2"
+          variant="surface"
+          className="border border-dashed border-white/20 bg-transparent"
+        >
+          <Flex direction="column" gap="2">
+            <Heading as="h3" size="4">
+              No collections yet
+            </Heading>
+            <Text size="2" color="gray">
+              Use the form above to create your first collection and start
+              saving links.
+            </Text>
+          </Flex>
+        </Card>
+      )}
+
+      <Dialog.Root
+        open={isEditing && !!activeCollection}
+        onOpenChange={(open) => {
+          setIsEditing(open);
+          if (!open) {
+            setActiveCollectionId(null);
+          }
+        }}
+      >
+        <Dialog.Content maxWidth="450px">
+          <Dialog.Title>Edit collection</Dialog.Title>
+          <Dialog.Description>
+            Update the collection name or description.
+          </Dialog.Description>
+          <form
+            onSubmit={handleEditSubmit}
+            className="mt-4"
+            key={activeCollection?.id ?? "new"}
+          >
+            <Flex direction="column" gap="3">
+              <TextField.Root
+                name="name"
+                defaultValue={activeCollection?.name ?? ""}
+                required
+                disabled={isUpdating}
+                aria-label="Collection name"
+              />
+              <TextArea
+                name="description"
+                defaultValue={activeCollection?.description ?? ""}
+                rows={3}
+                disabled={isUpdating}
+                aria-label="Collection description"
+              />
+              <Flex gap="3" justify="end">
+                <Button
+                  type="button"
+                  variant="soft"
+                  color="gray"
+                  onClick={() => {
+                    setIsEditing(false);
+                    setActiveCollectionId(null);
+                  }}
+                  disabled={isUpdating}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isUpdating}>
+                  {isUpdating ? "Saving..." : "Save changes"}
+                </Button>
+              </Flex>
+            </Flex>
+          </form>
+        </Dialog.Content>
+      </Dialog.Root>
+
+      <Dialog.Root
+        open={isDeleting && !!activeCollection}
+        onOpenChange={(open) => {
+          setIsDeleting(open);
+          if (!open) {
+            setActiveCollectionId(null);
+          }
+        }}
+      >
+        <Dialog.Content maxWidth="400px">
+          <Dialog.Title>Delete collection</Dialog.Title>
+          <Dialog.Description>
+            This action cannot be undone. All links in this collection will be
+            removed.
+          </Dialog.Description>
+          <Flex direction="column" gap="3" mt="4">
+            <Text>
+              Are you sure you want to delete{" "}
+              <strong>{activeCollection?.name}</strong>?
+            </Text>
+            <Flex gap="3" justify="end">
+              <Button
+                type="button"
+                variant="soft"
+                color="gray"
+                onClick={() => {
+                  setIsDeleting(false);
+                  setActiveCollectionId(null);
+                }}
+                disabled={isDeletingCollection}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                color="red"
+                onClick={handleDelete}
+                disabled={isDeletingCollection}
+              >
+                {isDeletingCollection ? "Deleting..." : "Delete"}
+              </Button>
+            </Flex>
+          </Flex>
+        </Dialog.Content>
+      </Dialog.Root>
+    </Flex>
+  );
+}

--- a/src/app/_components/sortable-collection-item.tsx
+++ b/src/app/_components/sortable-collection-item.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { type CSSProperties } from "react";
+import Link from "next/link";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  Button,
+  Card,
+  Flex,
+  Heading,
+  IconButton,
+  Text,
+  Tooltip,
+} from "@radix-ui/themes";
+import {
+  DotsVerticalIcon,
+  Pencil2Icon,
+  TrashIcon,
+} from "@radix-ui/react-icons";
+
+import type { DashboardCollectionModel } from "./dashboard-collections-manager";
+
+type SortableCollectionItemProps = {
+  collection: DashboardCollectionModel;
+  onEdit: () => void;
+  onDelete: () => void;
+  dragDisabled?: boolean;
+};
+
+export function SortableCollectionItem({
+  collection,
+  onEdit,
+  onDelete,
+  dragDisabled = false,
+}: SortableCollectionItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: collection.id, disabled: dragDisabled });
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : undefined,
+  };
+
+  const dragProps = dragDisabled ? {} : { ...attributes, ...listeners };
+
+  return (
+    <Card
+      ref={setNodeRef}
+      style={style}
+      variant="classic"
+      className="border-white/10 bg-black/40"
+    >
+      <Flex
+        direction={{ initial: "column", sm: "row" }}
+        align={{ initial: "start", sm: "center" }}
+        justify="between"
+        gap="3"
+      >
+        <Flex align="start" gap="3" className="flex-1">
+          <Tooltip
+            content={
+              dragDisabled
+                ? "Reordering disabled while saving"
+                : "Drag to reorder collections"
+            }
+          >
+            <IconButton
+              variant="soft"
+              color="gray"
+              {...dragProps}
+              disabled={dragDisabled}
+            >
+              <DotsVerticalIcon />
+            </IconButton>
+          </Tooltip>
+          <Flex direction="column" gap="2" className="flex-1">
+            <Heading as="h3" size="4">
+              <Link
+                href={`/collections/${collection.id}`}
+                className="text-white hover:underline"
+              >
+                {collection.name}
+              </Link>
+            </Heading>
+            {collection.description ? (
+              <Text size="2" color="gray">
+                {collection.description}
+              </Text>
+            ) : null}
+          </Flex>
+        </Flex>
+        <Flex
+          align={{ initial: "start", sm: "center" }}
+          gap="3"
+          direction={{ initial: "column", sm: "row" }}
+        >
+          <Text size="2" color="gray">
+            {collection.linkCount.toLocaleString()}{" "}
+            {collection.linkCount === 1 ? "link" : "links"}
+          </Text>
+          <Button size="2" variant="soft" asChild>
+            <Link href={`/collections/${collection.id}`}>Open</Link>
+          </Button>
+          <Tooltip content="Edit collection">
+            <IconButton variant="outline" onClick={onEdit}>
+              <Pencil2Icon />
+            </IconButton>
+          </Tooltip>
+          <Tooltip content="Delete collection">
+            <IconButton variant="outline" color="red" onClick={onDelete}>
+              <TrashIcon />
+            </IconButton>
+          </Tooltip>
+        </Flex>
+      </Flex>
+    </Card>
+  );
+}

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -98,7 +98,9 @@ if (useMock) {
           args,
         )) as CollectionRecord | null,
       create: (args) => prismaClient.collection.create(args),
+      update: (args) => prismaClient.collection.update(args),
       updateMany: (args) => prismaClient.collection.updateMany(args),
+      delete: (args) => prismaClient.collection.delete(args),
       deleteMany: (args) => prismaClient.collection.deleteMany(args),
     },
     link: {

--- a/src/server/db.types.ts
+++ b/src/server/db.types.ts
@@ -11,7 +11,11 @@ export type LinkRecord = Link & {
 
 export type LinkListDatabase = {
   $transaction(
-    operations: Array<(() => Promise<unknown>) | Promise<unknown>>,
+    operations: Array<
+      | (() => Promise<unknown>)
+      | Promise<unknown>
+      | Prisma.PrismaPromise<unknown>
+    >,
   ): Promise<unknown[]>;
   collection: {
     findMany(args?: Prisma.CollectionFindManyArgs): Promise<CollectionRecord[]>;
@@ -19,9 +23,11 @@ export type LinkListDatabase = {
       args?: Prisma.CollectionFindFirstArgs,
     ): Promise<CollectionRecord | null>;
     create(args: Prisma.CollectionCreateArgs): Promise<Collection>;
+    update(args: Prisma.CollectionUpdateArgs): Promise<Collection>;
     updateMany(
       args: Prisma.CollectionUpdateManyArgs,
     ): Promise<Prisma.BatchPayload>;
+    delete(args: Prisma.CollectionDeleteArgs): Promise<Collection>;
     deleteMany(
       args: Prisma.CollectionDeleteManyArgs,
     ): Promise<Prisma.BatchPayload>;

--- a/src/test/collectionRouter.spec.ts
+++ b/src/test/collectionRouter.spec.ts
@@ -251,13 +251,13 @@ describe("collectionRouter (mocked)", () => {
     });
 
     const intruder = createTestCaller({ session: createSession("user2") });
-    const updateResult = await intruder.collection.update({
-      id: created.id,
-      name: "Hacked",
-      description: "should not change",
-    });
-
-    expect(updateResult.count).toBe(0);
+    await expect(
+      intruder.collection.update({
+        id: created.id,
+        name: "Hacked",
+        description: "should not change",
+      }),
+    ).rejects.toThrow();
 
     const intruderView = await intruder.collection.getById({ id: created.id });
     expect(intruderView).toBeNull();


### PR DESCRIPTION
## Summary
- allow dashboard collections to be renamed, reordered, and deleted from a new client manager component
- add collection ordering support across the API, schema, and mock database with a reorder mutation
- update collection tests to reflect new behavior and ensure ordering works in both real and mock layers

## Testing
- npm run format:write
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68eb77a006bc832a80fcb2d277ab5b04