### PR TITLE
Refactor collection management components and router utilities

### DIFF
--- a/src/app/_components/collection-links-manager.tsx
+++ b/src/app/_components/collection-links-manager.tsx
@@ -1,48 +1,25 @@
 "use client";
 
-import {
-  Button,
-  Callout,
-  Dialog,
-  Flex,
-  Switch,
-  Text,
-  TextField,
-} from "@radix-ui/themes";
-import {
-  DndContext,
-  type DragEndEvent,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
-import {
-  SortableContext,
-  arrayMove,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
+import { useMemo, useState } from "react";
+import { DndContext } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import { Callout, Flex, Switch, Text, TextField } from "@radix-ui/themes";
 import {
   CheckIcon,
   DotsHorizontalIcon,
   ExclamationTriangleIcon,
 } from "@radix-ui/react-icons";
-import { useEffect, useMemo, useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
-
-import { api } from "@/trpc/react";
 
 import { SortableLinkItem } from "./sortable-link-item";
+import {
+  DeleteLinkDialog,
+  EditLinkDialog,
+} from "./collection-links-manager/link-dialogs";
+import { useCollectionLinksManager } from "./collection-links-manager/use-collection-links-manager";
+import type { CollectionLinkModel } from "./collection-links-manager/types";
 
-export type CollectionLinkModel = {
-  id: string;
-  name: string;
-  url: string;
-  comment: string | null;
-  order: number;
-};
-
-type Feedback = { type: "success" | "error"; message: string } | null;
+export type { CollectionLinkModel } from "./collection-links-manager/types";
 
 type CollectionLinksManagerProps = {
   collectionId: string;
@@ -55,119 +32,48 @@ export function CollectionLinksManager({
   initialLinks,
   initialIsPublic,
 }: CollectionLinksManagerProps) {
-  const [links, setLinks] = useState(initialLinks);
-  const [filterTerm, setFilterTerm] = useState("");
-  const [isPublic, setIsPublic] = useState(initialIsPublic);
+  const {
+    sensors,
+    links,
+    filteredLinks,
+    hasFilter,
+    filterTerm,
+    setFilterTerm,
+    feedback,
+    isPublic,
+    toggleVisibility,
+    handleDragEnd,
+    updateLink,
+    deleteLink,
+    isReordering,
+    isUpdating,
+    isDeleting,
+    isVisibilityUpdating,
+  } = useCollectionLinksManager({
+    collectionId,
+    initialLinks,
+    initialIsPublic,
+  });
+
   const [selectedLinkId, setSelectedLinkId] = useState<string | null>(null);
   const [isEditing, setIsEditing] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [feedback, setFeedback] = useState<Feedback>(null);
-  const utils = api.useUtils();
-  const router = useRouter();
-  const [, startTransition] = useTransition();
-
-  useEffect(() => {
-    setLinks(initialLinks);
-  }, [initialLinks]);
-
-  useEffect(() => {
-    setIsPublic(initialIsPublic);
-  }, [initialIsPublic]);
-
-  useEffect(() => {
-    if (!feedback) return;
-    const timeout = setTimeout(() => setFeedback(null), 3000);
-    return () => clearTimeout(timeout);
-  }, [feedback]);
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: { distance: 10 },
-    }),
-  );
-
-  const reorderMutation = api.link.reorder.useMutation({
-    onSettled: async () => {
-      await utils.collection.getById.invalidate({ id: collectionId });
-      router.refresh();
-    },
-  });
-
-  const updateMutation = api.link.update.useMutation({
-    onSettled: async () => {
-      await utils.collection.getById.invalidate({ id: collectionId });
-      router.refresh();
-    },
-  });
-
-  const deleteMutation = api.link.delete.useMutation({
-    onSettled: async () => {
-      await utils.collection.getById.invalidate({ id: collectionId });
-      router.refresh();
-    },
-  });
-
-  const visibilityMutation = api.collection.update.useMutation({
-    onSettled: async () => {
-      await utils.collection.getAll.invalidate();
-      await utils.collection.getById.invalidate({ id: collectionId });
-      router.refresh();
-    },
-  });
-
-  const filteredLinks = useMemo(() => {
-    if (!filterTerm.trim()) return links;
-    const query = filterTerm.trim().toLowerCase();
-    return links.filter((link) => {
-      return (
-        link.name.toLowerCase().includes(query) ||
-        link.url.toLowerCase().includes(query) ||
-        (link.comment?.toLowerCase().includes(query) ?? false)
-      );
-    });
-  }, [links, filterTerm]);
-
-  const hasFilter = filterTerm.trim().length > 0;
+  const [isDeletingDialogOpen, setIsDeletingDialogOpen] = useState(false);
 
   const activeLink = useMemo(
     () => links.find((link) => link.id === selectedLinkId) ?? null,
     [links, selectedLinkId],
   );
 
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
-    if (!over || active.id === over.id) {
-      return;
-    }
+  const hasLinks = filteredLinks.length > 0;
 
-    setLinks((prev) => {
-      const oldIndex = prev.findIndex((link) => link.id === active.id);
-      const newIndex = prev.findIndex((link) => link.id === over.id);
-      const reordered = arrayMove(prev, oldIndex, newIndex);
+  const openEditDialog = (linkId: string) => {
+    setSelectedLinkId(linkId);
+    setIsEditing(true);
+  };
 
-      const previous = prev;
-      startTransition(() => {
-        reorderMutation.mutate(
-          {
-            collectionId,
-            linkIds: reordered.map((link) => link.id),
-          },
-          {
-            onSuccess: () =>
-              setFeedback({ type: "success", message: "Link order updated" }),
-            onError: () => {
-              setLinks(previous);
-              setFeedback({
-                type: "error",
-                message: "Unable to update link order",
-              });
-            },
-          },
-        );
-      });
-
-      return reordered;
-    });
+  const openDeleteDialog = (linkId: string) => {
+    setSelectedLinkId(linkId);
+    setIsDeletingDialogOpen(true);
   };
 
   const handleEditSubmit = (formData: FormData) => {
@@ -189,75 +95,34 @@ export function CollectionLinksManager({
       return;
     }
 
-    const previousLinks = links;
-    setLinks((prev) =>
-      prev.map((link) =>
-        link.id === activeLink.id ? { ...link, url, name, comment } : link,
-      ),
-    );
-
-    updateMutation.mutate(
-      { id: activeLink.id, url, name, comment },
+    updateLink(
+      activeLink.id,
+      { url, name, comment },
       {
         onSuccess: () => {
-          setFeedback({ type: "success", message: "Link updated" });
           setIsEditing(false);
           setSelectedLinkId(null);
         },
         onError: () => {
-          setLinks(previousLinks);
-          setFeedback({ type: "error", message: "Unable to update link" });
+          setIsEditing(false);
         },
       },
     );
   };
 
-  const handleDelete = () => {
+  const handleDeleteConfirm = () => {
     if (!activeLink) return;
 
-    const previousLinks = links;
-    setLinks((prev) => prev.filter((link) => link.id !== activeLink.id));
-    deleteMutation.mutate(
-      { id: activeLink.id },
-      {
-        onSuccess: () => {
-          setFeedback({ type: "success", message: "Link removed" });
-          setIsDeleting(false);
-          setSelectedLinkId(null);
-        },
-        onError: () => {
-          setLinks(previousLinks);
-          setFeedback({ type: "error", message: "Unable to delete link" });
-        },
+    deleteLink(activeLink.id, {
+      onSuccess: () => {
+        setIsDeletingDialogOpen(false);
+        setSelectedLinkId(null);
       },
-    );
-  };
-
-  const handleVisibilityToggle = (checked: boolean) => {
-    const previous = isPublic;
-    setIsPublic(checked);
-    visibilityMutation.mutate(
-      { id: collectionId, isPublic: checked },
-      {
-        onSuccess: () =>
-          setFeedback({
-            type: "success",
-            message: checked
-              ? "Collection is now public"
-              : "Collection is now private",
-          }),
-        onError: () => {
-          setIsPublic(previous);
-          setFeedback({
-            type: "error",
-            message: "Unable to update collection visibility",
-          });
-        },
+      onError: () => {
+        setIsDeletingDialogOpen(false);
       },
-    );
+    });
   };
-
-  const hasLinks = filteredLinks.length > 0;
 
   return (
     <>
@@ -268,7 +133,11 @@ export function CollectionLinksManager({
         className="mt-6 flex-col gap-4 sm:flex-row"
       >
         <Flex align="center" gap="2">
-          <Switch checked={isPublic} onCheckedChange={handleVisibilityToggle} />
+          <Switch
+            checked={isPublic}
+            onCheckedChange={toggleVisibility}
+            disabled={isDeleting || isUpdating || isVisibilityUpdating}
+          />
           <Text size="2" color="gray">
             {isPublic ? "Visible to anyone" : "Only you can see this"}
           </Text>
@@ -321,14 +190,8 @@ export function CollectionLinksManager({
               key={link.id}
               link={link}
               dragDisabled
-              onEdit={() => {
-                setSelectedLinkId(link.id);
-                setIsEditing(true);
-              }}
-              onDelete={() => {
-                setSelectedLinkId(link.id);
-                setIsDeleting(true);
-              }}
+              onEdit={() => openEditDialog(link.id)}
+              onDelete={() => openDeleteDialog(link.id)}
             />
           ))}
         </Flex>
@@ -347,14 +210,9 @@ export function CollectionLinksManager({
                 <SortableLinkItem
                   key={link.id}
                   link={link}
-                  onEdit={() => {
-                    setSelectedLinkId(link.id);
-                    setIsEditing(true);
-                  }}
-                  onDelete={() => {
-                    setSelectedLinkId(link.id);
-                    setIsDeleting(true);
-                  }}
+                  dragDisabled={isReordering}
+                  onEdit={() => openEditDialog(link.id)}
+                  onDelete={() => openDeleteDialog(link.id)}
                 />
               ))}
             </Flex>
@@ -362,75 +220,31 @@ export function CollectionLinksManager({
         </DndContext>
       )}
 
-      <Dialog.Root open={isEditing} onOpenChange={setIsEditing}>
-        <Dialog.Content maxWidth="400px">
-          <Dialog.Title>Edit Link</Dialog.Title>
-          <Dialog.Description>
-            Update the URL, title, or description for this link.
-          </Dialog.Description>
-          <form
-            className="mt-4 flex flex-col gap-3"
-            action={handleEditSubmit}
-            onSubmit={(event) => {
-              event.preventDefault();
-              const formData = new FormData(event.currentTarget);
-              handleEditSubmit(formData);
-            }}
-          >
-            <TextField.Root
-              name="url"
-              defaultValue={activeLink?.url ?? ""}
-              placeholder="https://example.com"
-              required
-            />
-            <TextField.Root
-              name="name"
-              defaultValue={activeLink?.name ?? ""}
-              placeholder="Display name"
-              required
-            />
-            <TextField.Root
-              name="comment"
-              defaultValue={activeLink?.comment ?? ""}
-              placeholder="Comment (optional)"
-            />
-            <Flex gap="3" justify="end">
-              <Dialog.Close>
-                <Button variant="soft" color="gray">
-                  Cancel
-                </Button>
-              </Dialog.Close>
-              <Button type="submit" loading={updateMutation.isPending}>
-                Save changes
-              </Button>
-            </Flex>
-          </form>
-        </Dialog.Content>
-      </Dialog.Root>
+      <EditLinkDialog
+        open={isEditing && !!activeLink}
+        onOpenChange={(open) => {
+          setIsEditing(open);
+          if (!open) {
+            setSelectedLinkId(null);
+          }
+        }}
+        link={activeLink}
+        onSubmit={handleEditSubmit}
+        isSubmitting={isUpdating}
+      />
 
-      <Dialog.Root open={isDeleting} onOpenChange={setIsDeleting}>
-        <Dialog.Content maxWidth="360px">
-          <Dialog.Title>Delete link</Dialog.Title>
-          <Dialog.Description>
-            This removes <strong>{activeLink?.name ?? "this link"}</strong> from
-            the collection. This action cannot be undone.
-          </Dialog.Description>
-          <Flex mt="4" gap="3" justify="end">
-            <Dialog.Close>
-              <Button variant="soft" color="gray">
-                Cancel
-              </Button>
-            </Dialog.Close>
-            <Button
-              color="red"
-              onClick={handleDelete}
-              loading={deleteMutation.isPending}
-            >
-              Delete
-            </Button>
-          </Flex>
-        </Dialog.Content>
-      </Dialog.Root>
+      <DeleteLinkDialog
+        open={isDeletingDialogOpen && !!activeLink}
+        onOpenChange={(open) => {
+          setIsDeletingDialogOpen(open);
+          if (!open) {
+            setSelectedLinkId(null);
+          }
+        }}
+        link={activeLink}
+        onConfirm={handleDeleteConfirm}
+        isDeleting={isDeleting}
+      />
     </>
   );
 }

--- a/src/app/_components/collection-links-manager/link-dialogs.tsx
+++ b/src/app/_components/collection-links-manager/link-dialogs.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Button, Dialog, Flex, TextField } from "@radix-ui/themes";
+
+import type { CollectionLinkModel } from "./types";
+
+type EditLinkDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  link: CollectionLinkModel | null;
+  onSubmit: (formData: FormData) => void;
+  isSubmitting: boolean;
+};
+
+type DeleteLinkDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  link: CollectionLinkModel | null;
+  onConfirm: () => void;
+  isDeleting: boolean;
+};
+
+export function EditLinkDialog({
+  open,
+  onOpenChange,
+  link,
+  onSubmit,
+  isSubmitting,
+}: EditLinkDialogProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content maxWidth="400px">
+        <Dialog.Title>Edit Link</Dialog.Title>
+        <Dialog.Description>
+          Update the URL, title, or description for this link.
+        </Dialog.Description>
+        <form
+          className="mt-4 flex flex-col gap-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const formData = new FormData(event.currentTarget);
+            onSubmit(formData);
+          }}
+          key={link?.id ?? "new"}
+        >
+          <TextField.Root
+            name="url"
+            defaultValue={link?.url ?? ""}
+            placeholder="https://example.com"
+            required
+          />
+          <TextField.Root
+            name="name"
+            defaultValue={link?.name ?? ""}
+            placeholder="Display name"
+            required
+          />
+          <TextField.Root
+            name="comment"
+            defaultValue={link?.comment ?? ""}
+            placeholder="Comment (optional)"
+          />
+          <Flex gap="3" justify="end">
+            <Dialog.Close>
+              <Button variant="soft" color="gray" disabled={isSubmitting}>
+                Cancel
+              </Button>
+            </Dialog.Close>
+            <Button type="submit" loading={isSubmitting}>
+              Save changes
+            </Button>
+          </Flex>
+        </form>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}
+
+export function DeleteLinkDialog({
+  open,
+  onOpenChange,
+  link,
+  onConfirm,
+  isDeleting,
+}: DeleteLinkDialogProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content maxWidth="360px">
+        <Dialog.Title>Delete link</Dialog.Title>
+        <Dialog.Description>
+          This removes <strong>{link?.name ?? "this link"}</strong> from the
+          collection. This action cannot be undone.
+        </Dialog.Description>
+        <Flex mt="4" gap="3" justify="end">
+          <Dialog.Close>
+            <Button variant="soft" color="gray" disabled={isDeleting}>
+              Cancel
+            </Button>
+          </Dialog.Close>
+          <Button color="red" onClick={onConfirm} loading={isDeleting}>
+            Delete
+          </Button>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/src/app/_components/collection-links-manager/types.ts
+++ b/src/app/_components/collection-links-manager/types.ts
@@ -1,0 +1,9 @@
+export type CollectionLinkModel = {
+  id: string;
+  name: string;
+  url: string;
+  comment: string | null;
+  order: number;
+};
+
+export type Feedback = { type: "success" | "error"; message: string } | null;

--- a/src/app/_components/collection-links-manager/use-collection-links-manager.ts
+++ b/src/app/_components/collection-links-manager/use-collection-links-manager.ts
@@ -1,0 +1,261 @@
+"use client";
+
+import {
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+  useCallback,
+} from "react";
+import { useRouter } from "next/navigation";
+import {
+  type DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
+
+import { api } from "@/trpc/react";
+
+import type { CollectionLinkModel, Feedback } from "./types";
+
+type OperationCallbacks = {
+  onSuccess?: () => void;
+  onError?: () => void;
+};
+
+type UpdatePayload = {
+  url: string;
+  name: string;
+  comment: string;
+};
+
+type UseCollectionLinksManagerOptions = {
+  collectionId: string;
+  initialLinks: CollectionLinkModel[];
+  initialIsPublic: boolean;
+};
+
+export function useCollectionLinksManager({
+  collectionId,
+  initialLinks,
+  initialIsPublic,
+}: UseCollectionLinksManagerOptions) {
+  const [links, setLinks] = useState(initialLinks);
+  const [filterTerm, setFilterTerm] = useState("");
+  const [isPublic, setIsPublic] = useState(initialIsPublic);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+  const utils = api.useUtils();
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+
+  useEffect(() => {
+    setLinks(initialLinks);
+  }, [initialLinks]);
+
+  useEffect(() => {
+    setIsPublic(initialIsPublic);
+  }, [initialIsPublic]);
+
+  useEffect(() => {
+    if (!feedback) return;
+    const timeout = setTimeout(() => setFeedback(null), 3000);
+    return () => clearTimeout(timeout);
+  }, [feedback]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 10 },
+    }),
+  );
+
+  const reorderMutation = api.link.reorder.useMutation({
+    onSettled: async () => {
+      await utils.collection.getById.invalidate({ id: collectionId });
+      router.refresh();
+    },
+  });
+
+  const updateMutation = api.link.update.useMutation({
+    onSettled: async () => {
+      await utils.collection.getById.invalidate({ id: collectionId });
+      router.refresh();
+    },
+  });
+
+  const deleteMutation = api.link.delete.useMutation({
+    onSettled: async () => {
+      await utils.collection.getById.invalidate({ id: collectionId });
+      router.refresh();
+    },
+  });
+
+  const visibilityMutation = api.collection.update.useMutation({
+    onSettled: async () => {
+      await utils.collection.getAll.invalidate();
+      await utils.collection.getById.invalidate({ id: collectionId });
+      router.refresh();
+    },
+  });
+
+  const filteredLinks = useMemo(() => {
+    if (!filterTerm.trim()) return links;
+    const query = filterTerm.trim().toLowerCase();
+    return links.filter((link) => {
+      return (
+        link.name.toLowerCase().includes(query) ||
+        link.url.toLowerCase().includes(query) ||
+        (link.comment?.toLowerCase().includes(query) ?? false)
+      );
+    });
+  }, [links, filterTerm]);
+
+  const hasFilter = filterTerm.trim().length > 0;
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) {
+        return;
+      }
+
+      setLinks((previousLinks) => {
+        const oldIndex = previousLinks.findIndex(
+          (link) => link.id === active.id,
+        );
+        const newIndex = previousLinks.findIndex((link) => link.id === over.id);
+
+        if (oldIndex === -1 || newIndex === -1) {
+          return previousLinks;
+        }
+
+        const reordered = arrayMove(previousLinks, oldIndex, newIndex);
+        const rollback = previousLinks;
+
+        startTransition(() => {
+          reorderMutation.mutate(
+            {
+              collectionId,
+              linkIds: reordered.map((link) => link.id),
+            },
+            {
+              onSuccess: () =>
+                setFeedback({ type: "success", message: "Link order updated" }),
+              onError: () => {
+                setLinks(rollback);
+                setFeedback({
+                  type: "error",
+                  message: "Unable to update link order",
+                });
+              },
+            },
+          );
+        });
+
+        return reordered;
+      });
+    },
+    [collectionId, reorderMutation, startTransition],
+  );
+
+  const updateLink = useCallback(
+    (
+      linkId: string,
+      updates: UpdatePayload,
+      callbacks: OperationCallbacks = {},
+    ) => {
+      const previousLinks = links;
+      setLinks((prev) =>
+        prev.map((link) =>
+          link.id === linkId ? { ...link, ...updates } : link,
+        ),
+      );
+
+      updateMutation.mutate(
+        { id: linkId, ...updates },
+        {
+          onSuccess: () => {
+            setFeedback({ type: "success", message: "Link updated" });
+            callbacks.onSuccess?.();
+          },
+          onError: () => {
+            setLinks(previousLinks);
+            setFeedback({ type: "error", message: "Unable to update link" });
+            callbacks.onError?.();
+          },
+        },
+      );
+    },
+    [links, updateMutation],
+  );
+
+  const deleteLink = useCallback(
+    (linkId: string, callbacks: OperationCallbacks = {}) => {
+      const previousLinks = links;
+      setLinks((prev) => prev.filter((link) => link.id !== linkId));
+
+      deleteMutation.mutate(
+        { id: linkId },
+        {
+          onSuccess: () => {
+            setFeedback({ type: "success", message: "Link removed" });
+            callbacks.onSuccess?.();
+          },
+          onError: () => {
+            setLinks(previousLinks);
+            setFeedback({ type: "error", message: "Unable to delete link" });
+            callbacks.onError?.();
+          },
+        },
+      );
+    },
+    [deleteMutation, links],
+  );
+
+  const toggleVisibility = useCallback(
+    (checked: boolean) => {
+      const previous = isPublic;
+      setIsPublic(checked);
+      visibilityMutation.mutate(
+        { id: collectionId, isPublic: checked },
+        {
+          onSuccess: () =>
+            setFeedback({
+              type: "success",
+              message: checked
+                ? "Collection is now public"
+                : "Collection is now private",
+            }),
+          onError: () => {
+            setIsPublic(previous);
+            setFeedback({
+              type: "error",
+              message: "Unable to update collection visibility",
+            });
+          },
+        },
+      );
+    },
+    [collectionId, isPublic, visibilityMutation],
+  );
+
+  return {
+    sensors,
+    links,
+    filteredLinks,
+    hasFilter,
+    filterTerm,
+    setFilterTerm,
+    feedback,
+    isPublic,
+    toggleVisibility,
+    handleDragEnd,
+    updateLink,
+    deleteLink,
+    isReordering: reorderMutation.isPending,
+    isUpdating: updateMutation.isPending,
+    isDeleting: deleteMutation.isPending,
+    isVisibilityUpdating: visibilityMutation.isPending,
+  };
+}

--- a/src/app/_components/dashboard-collections-manager.tsx
+++ b/src/app/_components/dashboard-collections-manager.tsx
@@ -1,52 +1,21 @@
 "use client";
 
-import {
-  type FormEvent,
-  useEffect,
-  useMemo,
-  useState,
-  useTransition,
-} from "react";
-import { useRouter } from "next/navigation";
-import {
-  Button,
-  Callout,
-  Card,
-  Dialog,
-  Flex,
-  Heading,
-  Text,
-  TextArea,
-  TextField,
-} from "@radix-ui/themes";
-import {
-  DndContext,
-  PointerSensor,
-  type DragEndEvent,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
-import {
-  SortableContext,
-  arrayMove,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
+import { useState } from "react";
+import { DndContext } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import { Callout, Card, Flex, Heading, Text } from "@radix-ui/themes";
 import { CheckIcon, ExclamationTriangleIcon } from "@radix-ui/react-icons";
 
-import { api } from "@/trpc/react";
-
 import { SortableCollectionItem } from "./sortable-collection-item";
+import {
+  DeleteCollectionDialog,
+  EditCollectionDialog,
+} from "./dashboard-collections-manager/collection-dialogs";
+import { useDashboardCollectionsManager } from "./dashboard-collections-manager/use-dashboard-collections-manager";
+import type { DashboardCollectionModel } from "./dashboard-collections-manager/types";
 
-export type DashboardCollectionModel = {
-  id: string;
-  name: string;
-  description: string | null;
-  order: number;
-  linkCount: number;
-};
-
-type Feedback = { type: "success" | "error"; message: string } | null;
+export type { DashboardCollectionModel } from "./dashboard-collections-manager/types";
 
 type DashboardCollectionsManagerProps = {
   initialCollections: DashboardCollectionModel[];
@@ -55,110 +24,40 @@ type DashboardCollectionsManagerProps = {
 export function DashboardCollectionsManager({
   initialCollections,
 }: DashboardCollectionsManagerProps) {
-  const [collections, setCollections] = useState(initialCollections);
+  const {
+    sensors,
+    collections,
+    feedback,
+    handleDragEnd,
+    updateCollection,
+    deleteCollection,
+    getCollectionById,
+    isReordering,
+    isUpdating,
+    isDeleting,
+  } = useDashboardCollectionsManager({ initialCollections });
+
   const [activeCollectionId, setActiveCollectionId] = useState<string | null>(
     null,
   );
-  const [isEditing, setIsEditing] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [feedback, setFeedback] = useState<Feedback>(null);
-  const utils = api.useUtils();
-  const router = useRouter();
-  const [, startTransition] = useTransition();
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
-  useEffect(() => {
-    setCollections(initialCollections);
-  }, [initialCollections]);
+  const activeCollection = getCollectionById(activeCollectionId);
 
-  useEffect(() => {
-    if (!feedback) return;
-    const timeout = setTimeout(() => setFeedback(null), 3000);
-    return () => clearTimeout(timeout);
-  }, [feedback]);
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: { distance: 10 },
-    }),
-  );
-
-  const reorderMutation = api.collection.reorder.useMutation({
-    onSettled: async () => {
-      await utils.collection.getAll.invalidate();
-      router.refresh();
-    },
-  });
-
-  const updateMutation = api.collection.update.useMutation({
-    onSettled: async () => {
-      await utils.collection.getAll.invalidate();
-      router.refresh();
-    },
-  });
-
-  const deleteMutation = api.collection.delete.useMutation({
-    onSettled: async () => {
-      await utils.collection.getAll.invalidate();
-      router.refresh();
-    },
-  });
-
-  const activeCollection = useMemo(
-    () =>
-      collections.find((collection) => collection.id === activeCollectionId) ??
-      null,
-    [collections, activeCollectionId],
-  );
-
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
-    if (!over || active.id === over.id) {
-      return;
-    }
-
-    setCollections((prev) => {
-      const oldIndex = prev.findIndex(
-        (collection) => collection.id === active.id,
-      );
-      const newIndex = prev.findIndex(
-        (collection) => collection.id === over.id,
-      );
-      if (oldIndex === -1 || newIndex === -1) {
-        return prev;
-      }
-
-      const reordered = arrayMove(prev, oldIndex, newIndex);
-      const previous = prev;
-
-      startTransition(() => {
-        reorderMutation.mutate(
-          { collectionIds: reordered.map((collection) => collection.id) },
-          {
-            onSuccess: () =>
-              setFeedback({
-                type: "success",
-                message: "Collection order updated",
-              }),
-            onError: () => {
-              setCollections(previous);
-              setFeedback({
-                type: "error",
-                message: "Unable to update collection order",
-              });
-            },
-          },
-        );
-      });
-
-      return reordered;
-    });
+  const openEditDialog = (collectionId: string) => {
+    setActiveCollectionId(collectionId);
+    setIsEditDialogOpen(true);
   };
 
-  const handleEditSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const openDeleteDialog = (collectionId: string) => {
+    setActiveCollectionId(collectionId);
+    setIsDeleteDialogOpen(true);
+  };
+
+  const handleEditSubmit = (formData: FormData) => {
     if (!activeCollection) return;
 
-    const formData = new FormData(event.currentTarget);
     const nameValue = formData.get("name");
     const descriptionValue = formData.get("description");
 
@@ -173,37 +72,16 @@ export function DashboardCollectionsManager({
       return;
     }
 
-    const previousCollections = collections;
-    setCollections((prev) =>
-      prev.map((collection) =>
-        collection.id === activeCollection.id
-          ? {
-              ...collection,
-              name,
-              description: description.length > 0 ? description : null,
-            }
-          : collection,
-      ),
-    );
-
-    updateMutation.mutate(
-      {
-        id: activeCollection.id,
-        name,
-        description: description.length > 0 ? description : null,
-      },
+    updateCollection(
+      activeCollection.id,
+      { name, description: description.length > 0 ? description : null },
       {
         onSuccess: () => {
-          setFeedback({ type: "success", message: "Collection updated" });
-          setIsEditing(false);
+          setIsEditDialogOpen(false);
           setActiveCollectionId(null);
         },
         onError: () => {
-          setCollections(previousCollections);
-          setFeedback({
-            type: "error",
-            message: "Unable to update collection",
-          });
+          setIsEditDialogOpen(false);
         },
       },
     );
@@ -212,33 +90,16 @@ export function DashboardCollectionsManager({
   const handleDelete = () => {
     if (!activeCollection) return;
 
-    const previousCollections = collections;
-    setCollections((prev) =>
-      prev.filter((collection) => collection.id !== activeCollection.id),
-    );
-
-    deleteMutation.mutate(
-      { id: activeCollection.id },
-      {
-        onSuccess: () => {
-          setFeedback({ type: "success", message: "Collection deleted" });
-          setIsDeleting(false);
-          setActiveCollectionId(null);
-          router.refresh();
-        },
-        onError: () => {
-          setCollections(previousCollections);
-          setFeedback({
-            type: "error",
-            message: "Unable to delete collection",
-          });
-        },
+    deleteCollection(activeCollection.id, {
+      onSuccess: () => {
+        setIsDeleteDialogOpen(false);
+        setActiveCollectionId(null);
       },
-    );
+      onError: () => {
+        setIsDeleteDialogOpen(false);
+      },
+    });
   };
-
-  const isUpdating = updateMutation.isPending;
-  const isDeletingCollection = deleteMutation.isPending;
 
   return (
     <Flex direction="column" gap="4">
@@ -273,15 +134,9 @@ export function DashboardCollectionsManager({
                 <SortableCollectionItem
                   key={collection.id}
                   collection={collection}
-                  onEdit={() => {
-                    setActiveCollectionId(collection.id);
-                    setIsEditing(true);
-                  }}
-                  onDelete={() => {
-                    setActiveCollectionId(collection.id);
-                    setIsDeleting(true);
-                  }}
-                  dragDisabled={reorderMutation.isPending}
+                  onEdit={() => openEditDialog(collection.id)}
+                  onDelete={() => openDeleteDialog(collection.id)}
+                  dragDisabled={isReordering}
                 />
               ))}
             </Flex>
@@ -305,107 +160,31 @@ export function DashboardCollectionsManager({
         </Card>
       )}
 
-      <Dialog.Root
-        open={isEditing && !!activeCollection}
+      <EditCollectionDialog
+        open={isEditDialogOpen && !!activeCollection}
         onOpenChange={(open) => {
-          setIsEditing(open);
+          setIsEditDialogOpen(open);
           if (!open) {
             setActiveCollectionId(null);
           }
         }}
-      >
-        <Dialog.Content maxWidth="450px">
-          <Dialog.Title>Edit collection</Dialog.Title>
-          <Dialog.Description>
-            Update the collection name or description.
-          </Dialog.Description>
-          <form
-            onSubmit={handleEditSubmit}
-            className="mt-4"
-            key={activeCollection?.id ?? "new"}
-          >
-            <Flex direction="column" gap="3">
-              <TextField.Root
-                name="name"
-                defaultValue={activeCollection?.name ?? ""}
-                required
-                disabled={isUpdating}
-                aria-label="Collection name"
-              />
-              <TextArea
-                name="description"
-                defaultValue={activeCollection?.description ?? ""}
-                rows={3}
-                disabled={isUpdating}
-                aria-label="Collection description"
-              />
-              <Flex gap="3" justify="end">
-                <Button
-                  type="button"
-                  variant="soft"
-                  color="gray"
-                  onClick={() => {
-                    setIsEditing(false);
-                    setActiveCollectionId(null);
-                  }}
-                  disabled={isUpdating}
-                >
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={isUpdating}>
-                  {isUpdating ? "Saving..." : "Save changes"}
-                </Button>
-              </Flex>
-            </Flex>
-          </form>
-        </Dialog.Content>
-      </Dialog.Root>
+        collection={activeCollection}
+        onSubmit={handleEditSubmit}
+        isSubmitting={isUpdating}
+      />
 
-      <Dialog.Root
-        open={isDeleting && !!activeCollection}
+      <DeleteCollectionDialog
+        open={isDeleteDialogOpen && !!activeCollection}
         onOpenChange={(open) => {
-          setIsDeleting(open);
+          setIsDeleteDialogOpen(open);
           if (!open) {
             setActiveCollectionId(null);
           }
         }}
-      >
-        <Dialog.Content maxWidth="400px">
-          <Dialog.Title>Delete collection</Dialog.Title>
-          <Dialog.Description>
-            This action cannot be undone. All links in this collection will be
-            removed.
-          </Dialog.Description>
-          <Flex direction="column" gap="3" mt="4">
-            <Text>
-              Are you sure you want to delete{" "}
-              <strong>{activeCollection?.name}</strong>?
-            </Text>
-            <Flex gap="3" justify="end">
-              <Button
-                type="button"
-                variant="soft"
-                color="gray"
-                onClick={() => {
-                  setIsDeleting(false);
-                  setActiveCollectionId(null);
-                }}
-                disabled={isDeletingCollection}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="button"
-                color="red"
-                onClick={handleDelete}
-                disabled={isDeletingCollection}
-              >
-                {isDeletingCollection ? "Deleting..." : "Delete"}
-              </Button>
-            </Flex>
-          </Flex>
-        </Dialog.Content>
-      </Dialog.Root>
+        collection={activeCollection}
+        onConfirm={handleDelete}
+        isDeleting={isDeleting}
+      />
     </Flex>
   );
 }

--- a/src/app/_components/dashboard-collections-manager/collection-dialogs.tsx
+++ b/src/app/_components/dashboard-collections-manager/collection-dialogs.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import {
+  Button,
+  Dialog,
+  Flex,
+  Text,
+  TextArea,
+  TextField,
+} from "@radix-ui/themes";
+
+import type { DashboardCollectionModel } from "./types";
+
+type EditCollectionDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  collection: DashboardCollectionModel | null;
+  onSubmit: (formData: FormData) => void;
+  isSubmitting: boolean;
+};
+
+type DeleteCollectionDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  collection: DashboardCollectionModel | null;
+  onConfirm: () => void;
+  isDeleting: boolean;
+};
+
+export function EditCollectionDialog({
+  open,
+  onOpenChange,
+  collection,
+  onSubmit,
+  isSubmitting,
+}: EditCollectionDialogProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content maxWidth="450px">
+        <Dialog.Title>Edit collection</Dialog.Title>
+        <Dialog.Description>
+          Update the collection name or description.
+        </Dialog.Description>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            const formData = new FormData(event.currentTarget);
+            onSubmit(formData);
+          }}
+          className="mt-4"
+          key={collection?.id ?? "new"}
+        >
+          <Flex direction="column" gap="3">
+            <TextField.Root
+              name="name"
+              defaultValue={collection?.name ?? ""}
+              required
+              disabled={isSubmitting}
+              aria-label="Collection name"
+            />
+            <TextArea
+              name="description"
+              defaultValue={collection?.description ?? ""}
+              rows={3}
+              disabled={isSubmitting}
+              aria-label="Collection description"
+            />
+            <Flex gap="3" justify="end">
+              <Button
+                type="button"
+                variant="soft"
+                color="gray"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Saving..." : "Save changes"}
+              </Button>
+            </Flex>
+          </Flex>
+        </form>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}
+
+export function DeleteCollectionDialog({
+  open,
+  onOpenChange,
+  collection,
+  onConfirm,
+  isDeleting,
+}: DeleteCollectionDialogProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content maxWidth="400px">
+        <Dialog.Title>Delete collection</Dialog.Title>
+        <Dialog.Description>
+          This action cannot be undone. All links in this collection will be
+          removed.
+        </Dialog.Description>
+        <Flex direction="column" gap="3" mt="4">
+          <Text>
+            Are you sure you want to delete <strong>{collection?.name}</strong>?
+          </Text>
+          <Flex gap="3" justify="end">
+            <Button
+              type="button"
+              variant="soft"
+              color="gray"
+              onClick={() => onOpenChange(false)}
+              disabled={isDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              color="red"
+              onClick={onConfirm}
+              disabled={isDeleting}
+            >
+              {isDeleting ? "Deleting..." : "Delete"}
+            </Button>
+          </Flex>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/src/app/_components/dashboard-collections-manager/types.ts
+++ b/src/app/_components/dashboard-collections-manager/types.ts
@@ -1,0 +1,9 @@
+export type DashboardCollectionModel = {
+  id: string;
+  name: string;
+  description: string | null;
+  order: number;
+  linkCount: number;
+};
+
+export type Feedback = { type: "success" | "error"; message: string } | null;

--- a/src/app/_components/dashboard-collections-manager/use-dashboard-collections-manager.ts
+++ b/src/app/_components/dashboard-collections-manager/use-dashboard-collections-manager.ts
@@ -1,0 +1,222 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from "react";
+import { useRouter } from "next/navigation";
+import {
+  type DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
+
+import { api } from "@/trpc/react";
+
+import type { DashboardCollectionModel, Feedback } from "./types";
+
+type OperationCallbacks = {
+  onSuccess?: () => void;
+  onError?: () => void;
+};
+
+type UpdatePayload = {
+  name: string;
+  description: string | null;
+};
+
+type UseDashboardCollectionsManagerOptions = {
+  initialCollections: DashboardCollectionModel[];
+};
+
+export function useDashboardCollectionsManager({
+  initialCollections,
+}: UseDashboardCollectionsManagerOptions) {
+  const [collections, setCollections] = useState(initialCollections);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+  const utils = api.useUtils();
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+
+  useEffect(() => {
+    setCollections(initialCollections);
+  }, [initialCollections]);
+
+  useEffect(() => {
+    if (!feedback) return;
+    const timeout = setTimeout(() => setFeedback(null), 3000);
+    return () => clearTimeout(timeout);
+  }, [feedback]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 10 },
+    }),
+  );
+
+  const reorderMutation = api.collection.reorder.useMutation({
+    onSettled: async () => {
+      await utils.collection.getAll.invalidate();
+      router.refresh();
+    },
+  });
+
+  const updateMutation = api.collection.update.useMutation({
+    onSettled: async () => {
+      await utils.collection.getAll.invalidate();
+      router.refresh();
+    },
+  });
+
+  const deleteMutation = api.collection.delete.useMutation({
+    onSettled: async () => {
+      await utils.collection.getAll.invalidate();
+      router.refresh();
+    },
+  });
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) {
+        return;
+      }
+
+      setCollections((previousCollections) => {
+        const oldIndex = previousCollections.findIndex(
+          (collection) => collection.id === active.id,
+        );
+        const newIndex = previousCollections.findIndex(
+          (collection) => collection.id === over.id,
+        );
+
+        if (oldIndex === -1 || newIndex === -1) {
+          return previousCollections;
+        }
+
+        const reordered = arrayMove(previousCollections, oldIndex, newIndex);
+        const rollback = previousCollections;
+
+        startTransition(() => {
+          reorderMutation.mutate(
+            { collectionIds: reordered.map((collection) => collection.id) },
+            {
+              onSuccess: () =>
+                setFeedback({
+                  type: "success",
+                  message: "Collection order updated",
+                }),
+              onError: () => {
+                setCollections(rollback);
+                setFeedback({
+                  type: "error",
+                  message: "Unable to update collection order",
+                });
+              },
+            },
+          );
+        });
+
+        return reordered;
+      });
+    },
+    [reorderMutation, startTransition],
+  );
+
+  const updateCollection = useCallback(
+    (
+      collectionId: string,
+      updates: UpdatePayload,
+      callbacks: OperationCallbacks = {},
+    ) => {
+      const previousCollections = collections;
+      setCollections((prev) =>
+        prev.map((collection) =>
+          collection.id === collectionId
+            ? { ...collection, ...updates }
+            : collection,
+        ),
+      );
+
+      updateMutation.mutate(
+        { id: collectionId, ...updates },
+        {
+          onSuccess: () => {
+            setFeedback({ type: "success", message: "Collection updated" });
+            callbacks.onSuccess?.();
+          },
+          onError: () => {
+            setCollections(previousCollections);
+            setFeedback({
+              type: "error",
+              message: "Unable to update collection",
+            });
+            callbacks.onError?.();
+          },
+        },
+      );
+    },
+    [collections, updateMutation],
+  );
+
+  const deleteCollection = useCallback(
+    (collectionId: string, callbacks: OperationCallbacks = {}) => {
+      const previousCollections = collections;
+      setCollections((prev) =>
+        prev.filter((collection) => collection.id !== collectionId),
+      );
+
+      deleteMutation.mutate(
+        { id: collectionId },
+        {
+          onSuccess: () => {
+            setFeedback({ type: "success", message: "Collection deleted" });
+            callbacks.onSuccess?.();
+          },
+          onError: () => {
+            setCollections(previousCollections);
+            setFeedback({
+              type: "error",
+              message: "Unable to delete collection",
+            });
+            callbacks.onError?.();
+          },
+        },
+      );
+    },
+    [collections, deleteMutation],
+  );
+
+  const activeCollectionLookup = useMemo(() => {
+    const lookup = new Map(
+      collections.map((collection) => [collection.id, collection]),
+    );
+    return lookup;
+  }, [collections]);
+
+  const getCollectionById = useCallback(
+    (collectionId: string | null) => {
+      if (!collectionId) return null;
+      return activeCollectionLookup.get(collectionId) ?? null;
+    },
+    [activeCollectionLookup],
+  );
+
+  return {
+    sensors,
+    collections,
+    feedback,
+    handleDragEnd,
+    updateCollection,
+    deleteCollection,
+    getCollectionById,
+    isReordering: reorderMutation.isPending,
+    isUpdating: updateMutation.isPending,
+    isDeleting: deleteMutation.isPending,
+  };
+}

--- a/src/app/_components/sortable-collection-item.tsx
+++ b/src/app/_components/sortable-collection-item.tsx
@@ -19,7 +19,7 @@ import {
   TrashIcon,
 } from "@radix-ui/react-icons";
 
-import type { DashboardCollectionModel } from "./dashboard-collections-manager";
+import type { DashboardCollectionModel } from "./dashboard-collections-manager/types";
 
 type SortableCollectionItemProps = {
   collection: DashboardCollectionModel;

--- a/src/app/_components/sortable-link-item.tsx
+++ b/src/app/_components/sortable-link-item.tsx
@@ -16,7 +16,7 @@ import {
   TrashIcon,
 } from "@radix-ui/react-icons";
 
-import type { CollectionLinkModel } from "./collection-links-manager";
+import type { CollectionLinkModel } from "./collection-links-manager/types";
 
 type SortableLinkItemProps = {
   link: CollectionLinkModel;

--- a/src/server/api/routers/collection.ts
+++ b/src/server/api/routers/collection.ts
@@ -5,177 +5,18 @@ import {
   createTRPCRouter,
   protectedProcedure,
   publicProcedure,
-  type TRPCContext,
 } from "@/server/api/trpc";
 
-const PUBLIC_CATALOG_DEFAULT_LIMIT = 12;
-const PUBLIC_CATALOG_DEFAULT_LINK_LIMIT = 10;
-
-const publicCatalogInputSchema = z.object({
-  q: z.string().trim().min(1).optional(),
-  limit: z.number().int().min(1).max(50).default(PUBLIC_CATALOG_DEFAULT_LIMIT),
-  cursor: z.string().min(1).optional(),
-  linkLimit: z
-    .number()
-    .int()
-    .min(1)
-    .max(10)
-    .default(PUBLIC_CATALOG_DEFAULT_LINK_LIMIT),
-});
-
-const publicLinkSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  url: z.string().url(),
-  comment: z.string().nullable(),
-  order: z.number().int(),
-});
-
-const publicCollectionSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  description: z.string().nullable(),
-  isPublic: z.literal(true),
-  updatedAt: z.string(),
-  topLinks: z.array(publicLinkSchema),
-});
-
-const publicCatalogResponseSchema = z.object({
-  items: z.array(publicCollectionSchema),
-  nextCursor: z.string().nullable(),
-  totalCount: z.number().int(),
-});
-
-type PublicCatalogInput = z.infer<typeof publicCatalogInputSchema>;
-type PublicCatalogItem = z.infer<typeof publicCollectionSchema>;
-type PublicCatalogResponse = z.infer<typeof publicCatalogResponseSchema>;
-
-const publicCatalogQuery = {
-  where: { isPublic: true },
-  include: {
-    links: {
-      orderBy: { order: "asc" as const },
-    },
-  },
-} as const;
-
-const normalizeDescription = (
-  value: string | null | undefined,
-): string | null => {
-  if (value === undefined) return null;
-  return value;
-};
-
-const normalizeDescriptionForUpdate = (
-  value: string | null | undefined,
-): string | null | undefined => {
-  if (value === undefined) return undefined;
-  if (value === null) return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-};
-
-const normalizeDescriptionForCreate = (
-  value: string | null | undefined,
-): string | null => {
-  if (value === undefined || value === null) return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-};
-
-const toIsoString = (value: Date | string): string => {
-  if (typeof value === "string") {
-    return value;
-  }
-  return value.toISOString();
-};
-
-const mapCollectionRecordToCatalogItem = (
-  collection: {
-    id: string;
-    name: string;
-    description: string | null;
-    isPublic: boolean;
-    updatedAt: Date | string;
-    links?: Array<{
-      id: string;
-      name: string;
-      url: string;
-      comment: string | null;
-      order: number;
-    }>;
-  },
-  linkLimit: number,
-): PublicCatalogItem => {
-  const links = Array.isArray(collection.links) ? collection.links : [];
-  const sortedLinks = [...links].sort((a, b) => a.order - b.order);
-  const trimmedLinks = sortedLinks.slice(0, linkLimit).map((link) => ({
-    id: link.id,
-    name: link.name,
-    url: link.url,
-    comment: link.comment,
-    order: link.order,
-  }));
-
-  return {
-    id: collection.id,
-    name: collection.name,
-    description: normalizeDescription(collection.description),
-    isPublic: true,
-    updatedAt: toIsoString(collection.updatedAt),
-    topLinks: trimmedLinks,
-  };
-};
-
-async function fetchPublicCatalog(
-  ctx: TRPCContext,
-  input: PublicCatalogInput,
-): Promise<PublicCatalogResponse> {
-  const query = input.q?.trim().toLowerCase();
-  const linkLimit = input.linkLimit ?? PUBLIC_CATALOG_DEFAULT_LINK_LIMIT;
-  const limit = input.limit ?? PUBLIC_CATALOG_DEFAULT_LIMIT;
-
-  const collections = await ctx.db.collection.findMany(publicCatalogQuery);
-
-  const filtered = collections.filter((collection) => {
-    if (!query) return true;
-    const haystack = [collection.name, collection.description ?? ""]
-      .join(" ")
-      .toLowerCase();
-    return haystack.includes(query);
-  });
-
-  const sorted = filtered.sort((a, b) => {
-    const dateDiff =
-      new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-    if (dateDiff !== 0) {
-      return dateDiff;
-    }
-    return b.id.localeCompare(a.id);
-  });
-
-  const allItems = sorted.map((collection) =>
-    mapCollectionRecordToCatalogItem(collection, linkLimit),
-  );
-
-  const totalCount = allItems.length;
-  const cursorId = input.cursor;
-  let startIndex = 0;
-  if (cursorId) {
-    const cursorIndex = allItems.findIndex((item) => item.id === cursorId);
-    startIndex = cursorIndex >= 0 ? cursorIndex + 1 : 0;
-  }
-  const pageItems = allItems.slice(startIndex, startIndex + limit);
-  const hasMore = startIndex + limit < allItems.length;
-  const lastItem = pageItems.at(-1);
-  const nextCursor = hasMore && lastItem ? lastItem.id : null;
-
-  return {
-    items: pageItems,
-    nextCursor,
-    totalCount,
-  } satisfies PublicCatalogResponse;
-}
+import {
+  PUBLIC_CATALOG_DEFAULT_LINK_LIMIT,
+  fetchPublicCatalog,
+  publicCatalogInputSchema,
+  publicCatalogResponseSchema,
+} from "./collection/catalog";
+import {
+  normalizeDescriptionForCreate,
+  normalizeDescriptionForUpdate,
+} from "./collection/normalizers";
 
 export const collectionRouter = createTRPCRouter({
   // Get the most recently updated public collection with links

--- a/src/server/api/routers/collection/catalog.ts
+++ b/src/server/api/routers/collection/catalog.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+
+import type { TRPCContext } from "@/server/api/trpc";
+
+import { normalizeDescription } from "./normalizers";
+
+export const PUBLIC_CATALOG_DEFAULT_LIMIT = 12;
+export const PUBLIC_CATALOG_DEFAULT_LINK_LIMIT = 10;
+
+const publicLinkSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  url: z.string().url(),
+  comment: z.string().nullable(),
+  order: z.number().int(),
+});
+
+const publicCollectionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  isPublic: z.literal(true),
+  updatedAt: z.string(),
+  topLinks: z.array(publicLinkSchema),
+});
+
+export const publicCatalogInputSchema = z.object({
+  q: z.string().trim().min(1).optional(),
+  limit: z.number().int().min(1).max(50).default(PUBLIC_CATALOG_DEFAULT_LIMIT),
+  cursor: z.string().min(1).optional(),
+  linkLimit: z
+    .number()
+    .int()
+    .min(1)
+    .max(10)
+    .default(PUBLIC_CATALOG_DEFAULT_LINK_LIMIT),
+});
+
+export const publicCatalogResponseSchema = z.object({
+  items: z.array(publicCollectionSchema),
+  nextCursor: z.string().nullable(),
+  totalCount: z.number().int(),
+});
+
+export type PublicCatalogInput = z.infer<typeof publicCatalogInputSchema>;
+export type PublicCatalogItem = z.infer<typeof publicCollectionSchema>;
+export type PublicCatalogResponse = z.infer<typeof publicCatalogResponseSchema>;
+
+type CollectionRecord = {
+  id: string;
+  name: string;
+  description: string | null;
+  isPublic: boolean;
+  updatedAt: Date | string;
+  links?: Array<{
+    id: string;
+    name: string;
+    url: string;
+    comment: string | null;
+    order: number;
+  }>;
+};
+
+const publicCatalogQuery = {
+  where: { isPublic: true },
+  include: {
+    links: {
+      orderBy: { order: "asc" as const },
+    },
+  },
+} as const;
+
+const toIsoString = (value: Date | string): string => {
+  if (typeof value === "string") {
+    return value;
+  }
+  return value.toISOString();
+};
+
+export const mapCollectionRecordToCatalogItem = (
+  collection: CollectionRecord,
+  linkLimit: number,
+): PublicCatalogItem => {
+  const links = Array.isArray(collection.links) ? collection.links : [];
+  const sortedLinks = [...links].sort((a, b) => a.order - b.order);
+  const trimmedLinks = sortedLinks.slice(0, linkLimit).map((link) => ({
+    id: link.id,
+    name: link.name,
+    url: link.url,
+    comment: link.comment,
+    order: link.order,
+  }));
+
+  return {
+    id: collection.id,
+    name: collection.name,
+    description: normalizeDescription(collection.description),
+    isPublic: true,
+    updatedAt: toIsoString(collection.updatedAt),
+    topLinks: trimmedLinks,
+  } satisfies PublicCatalogItem;
+};
+
+export async function fetchPublicCatalog(
+  ctx: TRPCContext,
+  input: PublicCatalogInput,
+): Promise<PublicCatalogResponse> {
+  const query = input.q?.trim().toLowerCase();
+  const linkLimit = input.linkLimit ?? PUBLIC_CATALOG_DEFAULT_LINK_LIMIT;
+  const limit = input.limit ?? PUBLIC_CATALOG_DEFAULT_LIMIT;
+
+  const collections = await ctx.db.collection.findMany(publicCatalogQuery);
+
+  const filtered = collections.filter((collection) => {
+    if (!query) return true;
+    const haystack = [collection.name, collection.description ?? ""]
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(query);
+  });
+
+  const sorted = filtered.sort((a, b) => {
+    const dateDiff =
+      new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+    if (dateDiff !== 0) {
+      return dateDiff;
+    }
+    return b.id.localeCompare(a.id);
+  });
+
+  const allItems = sorted.map((collection) =>
+    mapCollectionRecordToCatalogItem(collection, linkLimit),
+  );
+
+  const totalCount = allItems.length;
+  const cursorId = input.cursor;
+  let startIndex = 0;
+  if (cursorId) {
+    const cursorIndex = allItems.findIndex((item) => item.id === cursorId);
+    startIndex = cursorIndex >= 0 ? cursorIndex + 1 : 0;
+  }
+  const pageItems = allItems.slice(startIndex, startIndex + limit);
+  const hasMore = startIndex + limit < allItems.length;
+  const lastItem = pageItems.at(-1);
+  const nextCursor = hasMore && lastItem ? lastItem.id : null;
+
+  return {
+    items: pageItems,
+    nextCursor,
+    totalCount,
+  } satisfies PublicCatalogResponse;
+}

--- a/src/server/api/routers/collection/normalizers.ts
+++ b/src/server/api/routers/collection/normalizers.ts
@@ -1,0 +1,23 @@
+export const normalizeDescription = (
+  value: string | null | undefined,
+): string | null => {
+  if (value === undefined) return null;
+  return value;
+};
+
+export const normalizeDescriptionForUpdate = (
+  value: string | null | undefined,
+): string | null | undefined => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export const normalizeDescriptionForCreate = (
+  value: string | null | undefined,
+): string | null => {
+  if (value === undefined || value === null) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};


### PR DESCRIPTION
## Summary
- split the collection and dashboard managers into reusable hooks and dialog components to simplify the UI files
- extract catalog helpers and normalizers into dedicated server utilities to clarify the collection router
- update sortable item imports to use the shared types exported from the new helper modules

## Testing
- npm run format:write
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_6903320c6b34832ab4ebd0af058647e2