### PR TITLE
Potential fix for code scanning alert no. 2: Disabling certificate validation

### DIFF
--- a/scripts/inspect-pooler-cert.mjs
+++ b/scripts/inspect-pooler-cert.mjs
@@ -1,8 +1,13 @@
 import tls from 'tls';
 
-const [host, port, servername] = process.argv.slice(2);
+// Check for --insecure flag (optionally anywhere in arguments)
+const args = process.argv.slice(2);
+const insecureFlagIndex = args.indexOf('--insecure');
+const filteredArgs = insecureFlagIndex !== -1 ? args.filter((arg) => arg !== '--insecure') : args;
+const [host, port, servername] = filteredArgs;
 if (!host || !port) {
-  console.error('Usage: node scripts/inspect-pooler-cert.mjs <host> <port> [servername]');
+  console.error('Usage: node scripts/inspect-pooler-cert.mjs <host> <port> [servername] [--insecure]');
+  console.error('         --insecure disables certificate validation (NOT RECOMMENDED unless debugging non-compliant servers)');
   process.exit(2);
 }
 
@@ -10,8 +15,10 @@ const opts = {
   host,
   port: Number(port),
   servername: servername || host,
-  rejectUnauthorized: false, // we only want to inspect the chain
   timeout: 10000,
+if (insecureFlagIndex !== -1) {
+  opts.rejectUnauthorized = false; // disable cert validation only if explicitly requested
+}
 };
 
 const sock = tls.connect(opts, () => {


### PR DESCRIPTION
Potential fix for [https://github.com/deadronos/deadronosurllist/security/code-scanning/2](https://github.com/deadronos/deadronosurllist/security/code-scanning/2)

The best fix is to **require user confirmation to disable certificate validation**. By default, certificate validation should be enabled (`rejectUnauthorized: true` or omitted). Only if the user explicitly requests it (for example, by adding a `--insecure` or `--no-validate` flag on the command line), should the script use `rejectUnauthorized: false`. This approach makes the script safer for unwary users but retains the flexibility for debugging purposes. The following changes are needed:

- Parse command-line arguments for an additional `--insecure` (or similar) flag.
- Set `rejectUnauthorized: false` *only* if this flag is provided, otherwise omit it (so that validation is enabled).
- Update the usage/help message to indicate the presence of this flag.

All changes are within `scripts/inspect-pooler-cert.mjs`, and no new packages are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
