### PR TITLE
Preview

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Zod's `z.string().url()` validation accepts `javascript:`, `vbscript:`, and `data:` protocols, leading to Stored XSS when rendered in `href`.
 **Learning:** Standard URL validation in libraries often focuses on structure (RFC 3986) rather than safety. "Valid URL" != "Safe URL".
 **Prevention:** Explicitly whitelist allowed protocols (http/https) using `.refine()` or regex when validating URLs intended for user navigation.
+
+## 2025-02-18 - [DoS via Strict Output Validation]
+**Vulnerability:** Implementing strict validation on API outputs (e.g., throwing error on invalid URLs) can cause page crashes (DoS) if the database contains legacy invalid data.
+**Learning:** Defense in depth requires *resilience*. Simply validating output schemas is not enough; one must assume bad data exists and sanitize/filter it gracefully instead of failing the request.
+**Prevention:** Use `.filter()` or sanitization logic in mappers to remove invalid items before they hit strict schema validation or the frontend.

--- a/src/test/catalogSecurity.spec.ts
+++ b/src/test/catalogSecurity.spec.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createCaller } from "@/server/api/root";
+import { db } from "@/server/db";
+import type { LinkListDatabase } from "@/server/db.types";
+import type { Session } from "next-auth";
+
+type AppCaller = ReturnType<typeof createCaller>;
+
+type TestContext = {
+  db: LinkListDatabase;
+  session: Session | null;
+  headers: Headers;
+};
+
+const createSession = (userId: string): Session => ({
+  user: {
+    id: userId,
+    name: `Test ${userId}`,
+    email: null,
+    image: null,
+  },
+  expires: new Date(Date.now() + 60_000).toISOString(),
+});
+
+const createTestCaller = (overrides?: Partial<TestContext>): AppCaller => {
+  const context: TestContext = {
+    db,
+    session: createSession("user1"),
+    headers: new Headers(),
+    ...overrides,
+  };
+
+  return createCaller(context);
+};
+
+let caller: AppCaller;
+
+const maybeReset = (db as unknown as { reset?: () => void }).reset;
+
+beforeEach(() => {
+  if (typeof maybeReset === "function") {
+    maybeReset();
+  }
+  caller = createTestCaller();
+});
+
+describe("security reproduction", () => {
+  it("reproduces stored XSS by returning unsafe URLs from public catalog", async () => {
+    // 1. Create a public collection directly in the DB
+    const collection = await caller.collection.create({
+      name: "Malicious Collection",
+      description: "Contains unsafe links",
+      isPublic: true,
+    });
+
+    // 2. Inject a malicious link directly into the DB
+    await db.link.create({
+      data: {
+        collectionId: collection.id,
+        name: "Click me for XSS",
+        url: "javascript:alert('XSS')",
+        comment: "This should be filtered",
+        order: 1,
+      },
+    });
+
+    // Inject a safe link to ensure legitimate data remains
+    await db.link.create({
+        data: {
+          collectionId: collection.id,
+          name: "Safe Link",
+          url: "https://example.com",
+          comment: "This should be present",
+          order: 2,
+        },
+      });
+
+    // 3. Fetch the public catalog
+    const response = await caller.collection.getPublicCatalog({
+      limit: 10,
+    });
+
+    // 4. Find our collection
+    const item = response.items.find((i) => i.id === collection.id);
+    expect(item).toBeDefined();
+
+    // 5. Assert that the malicious link IS filtered out (fixing the vulnerability)
+    const badLink = item?.topLinks.find((l) => l.url === "javascript:alert('XSS')");
+    expect(badLink).toBeUndefined();
+
+    // 6. Assert that safe link is present
+    const safeLink = item?.topLinks.find((l) => l.url === "https://example.com");
+    expect(safeLink).toBeDefined();
+  });
+});


### PR DESCRIPTION
This pull request addresses a stored XSS vulnerability in the public catalog by ensuring only safe URLs (http/https) are accepted and returned. It introduces stricter URL validation in the schema, filters unsafe links at runtime, and adds a regression test to prevent reintroduction of this security issue. Additionally, a new security note is documented for future reference.

**Security improvements:**

* Added an `isSafeUrl` function to validate that only `http` and `https` URLs are accepted, preventing stored XSS via `javascript:` or similar protocols in the `publicLinkSchema`. (`src/server/api/routers/collection/catalog.ts`)
* Updated the catalog mapping logic to filter out unsafe links before returning them to clients, ensuring legacy or malicious data cannot cause XSS in the frontend. (`src/server/api/routers/collection/catalog.ts`)

**Testing and documentation:**

* Added a regression test that injects both malicious and safe links into a collection and verifies that only safe links are returned from the public catalog API. (`src/test/catalogSecurity.spec.ts`)
* Documented the new class of vulnerability (DoS via strict output validation) and the importance of resilience and filtering in `.jules/sentinel.md`.